### PR TITLE
Add siliconcompiler to python-requirements.txt

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,3 +1,4 @@
 bin2coe
 hjson
 mako
+siliconcompiler


### PR DESCRIPTION
Signed-off-by: Olof Kindgren <olof.kindgren@gmail.com>