### PR TITLE
Update library 'copy' field so the build works with the remote flow

### DIFF
--- a/build.py
+++ b/build.py
@@ -65,7 +65,7 @@ def configure_core_chip(remote=False):
     # server can access them
     if remote:
         stackup = chip.get('asic', 'stackup')
-        chip.set('library', 'sky130sram', 'model', 'timing', 'nldm', True, field='copy')
+        chip.set('library', 'sky130sram', 'model', 'timing', 'nldm', 'typical', True, field='copy')
         chip.set('library', 'sky130sram', 'model', 'layout', 'lef', stackup, True, field='copy')
         chip.set('library', 'sky130sram', 'model', 'layout', 'gds', stackup, True, field='copy')
 

--- a/libs/sky130sram.py
+++ b/libs/sky130sram.py
@@ -5,6 +5,9 @@ def setup(chip):
     lib = siliconcompiler.Chip(libname)
 
     stackup = '5M1LI' # TODO: this should this be extracted from something
+    version = 'v0_0_2'
+
+    lib.set('package', 'version', version)
 
     lib.set('asic', 'pdk', 'skywater130')
     lib.set('asic', 'stackup', stackup)


### PR DESCRIPTION
We need to add a corner to the timing model field to avoid key errors in the new schema.